### PR TITLE
Normalized metadata, updated metadata pattern

### DIFF
--- a/asst2/CODE/CMakeLists.txt
+++ b/asst2/CODE/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(tests
     my_pthread.c
     my_malloc.c
     open_address_ht.c
-    )
+    direct_mapping.c direct_mapping.h)
 target_link_libraries(tests -lrt -lm)
 
 add_executable(bchmk datastructs.c my_scheduler.c my_pthread.c data1.c my_malloc.c open_address_ht.c open_address_ht.h)

--- a/asst2/CODE/direct_mapping.c
+++ b/asst2/CODE/direct_mapping.c
@@ -1,0 +1,29 @@
+#include "direct_mapping.h"
+#include "global_vals.h"
+
+int dm_block_occupied(metadata* curr) {
+  return curr->size & 0x80;
+}
+
+int dm_is_last_segment(metadata* curr) {
+  return (curr->size & 0x40) >> 6;
+}
+
+uint8_t dm_block_size(metadata* curr) {
+  return (curr->size & 0x3f) + 1;
+}
+
+void dm_write_metadata(metadata* curr, size_t size, int occupied, int last) {
+  curr -> size = ((uint8_t)(size-1)) | (occupied << 7) | (last << 6);
+}
+
+void dm_allocate_block(metadata* curr, size_t size) {
+  uint8_t curr_seg = dm_block_size(curr);
+  int is_last_segment = dm_is_last_segment(curr);
+  if (size < curr_seg) {
+    dm_write_metadata(curr, size, 1, 0);
+    dm_write_metadata(curr+size*SEGMENTSIZE, curr_seg-size, 0, is_last_segment);
+  } else {
+    dm_write_metadata(curr, size, 1, is_last_segment);
+  }
+}

--- a/asst2/CODE/direct_mapping.c
+++ b/asst2/CODE/direct_mapping.c
@@ -2,7 +2,7 @@
 #include "global_vals.h"
 
 int dm_block_occupied(metadata* curr) {
-  return curr->size & 0x80;
+  return (curr->size & 0x80) >> 7;
 }
 
 int dm_is_last_segment(metadata* curr) {

--- a/asst2/CODE/direct_mapping.h
+++ b/asst2/CODE/direct_mapping.h
@@ -1,0 +1,50 @@
+#ifndef ASST2_DIRECT_MAPPING_H
+#define ASST2_DIRECT_MAPPING_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * Metadata consists of 8 bits arranged as follows:
+ * |f|l|norm-size|
+ * f          a 1-bit flag denoting whether the segment is occupied. 1 for
+ *            occupied, 0 for free.
+ *
+ * l          a 1-bit flag denoting whether the segment is the last segment in a
+ *            page.
+ *
+ * norm-size  a 6-bit number representing the "normalized" size of a segment.
+ *            A normalized size of n represents an actual segment size of n+1.
+ */
+struct metadata_ {
+  uint8_t size;
+} typedef metadata;
+
+// if the segment pointed by curr is occupied
+int dm_block_occupied(metadata* curr);
+
+// if curr points to the last segment in a page
+int dm_is_last_segment(metadata* curr);
+
+// the (de-normalized) length of the block curr points to
+uint8_t dm_block_size(metadata* curr);
+
+
+/**
+ * Writes a given configuration to the metadata byte pointed by curr.
+ * @param curr      the pointer.
+ * @param size      the length of segment.
+ * @param occupied  whether the segment is free or occupied.
+ * @param last      whether the segment is the last segment in the page.
+ */
+void dm_write_metadata(metadata* curr, size_t size, int occupied, int last);
+
+/**
+ * Allocate a segment at the pointed free block. Guaranteed to split the
+ * block if necessary.
+ * @param curr
+ * @param size
+ */
+void dm_allocate_block(metadata* curr, size_t size);
+
+#endif //ASST2_DIRECT_MAPPING_H

--- a/asst2/CODE/malloc_test.c
+++ b/asst2/CODE/malloc_test.c
@@ -46,14 +46,14 @@ void TEST_malloc_thread_create_join() {
 void TEST_malloc_directmapping() {
   char* ptrs[5]; 
   for (int i = 0 ; i < 5; i++) { 
-    char* p = (char*) myallocate(5*sizeof(char), __FILE__, __LINE__, LIBRARYREQ);
+    char* p = (char*) myallocate(5*sizeof(char), __FILE__, __LINE__, THREADREQ);
     strcpy(p,"help"); 
     ptrs[i] = p;
     printMemory();
   }
   for (int i = 0 ; i < 5; i++) { 
 //    printf("%s\n", ptrs[i]);
-    mydeallocate(ptrs[i], __FILE__, __LINE__, LIBRARYREQ);
+    mydeallocate(ptrs[i], __FILE__, __LINE__, THREADREQ);
     printMemory();
   }
 }

--- a/asst2/CODE/my_malloc.c
+++ b/asst2/CODE/my_malloc.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "my_malloc.h"
 #include "global_vals.h"
+#include "direct_mapping.h"
 
 static char* myblock;
 static int firstMalloc = 1;
@@ -18,34 +19,10 @@ static void handler(int sig, siginfo_t* si, void* unused) {
 	exit(0);
 }
 
-//user blocks are occupied (malloc'd) if the
-//left most bit of 8 bit of the metadata is 1,
-//so to check if a user data block is occupied:
-//calculate bitwise '&' of size and 0x80 (0b 1000 0000)
-//if result is 0, then the block is free, 
-//and return this so is_occupied = false
-//else we will return 0x80 which is true 
-int is_occupied(metadata* curr) {
-	return  (curr->size) & 0x80;
-}
-
-//ignores the leftmost bit in the metadata which represents free/malloc
-//to return the number of userdata blocks
-unsigned char block_size(metadata* curr) {
-	return curr -> size & 0x7f;
-}
-
-
 //prints any error messages followed by memory 
 void error_message(char* error, char* file, int line) {
 	printf("%s:%d: %s\n", file, line, error);
 	exit(0);
-}
-
-//takes the number of segments within page to be free and writes that into metadata
-void write_free_size(metadata* curr, size_t newSize) {
-	curr -> size = newSize & 0x7f;
-	return;
 }
 
 //takes the number of segments within page to be malloc'd
@@ -53,17 +30,19 @@ void write_free_size(metadata* curr, size_t newSize) {
 //to represent malloc'd and writes this into metadata
 //if the current free block is being split with this malloc
 //also creates a metadata block to adjust the size of free userdata available
-void write_occupied_size(metadata* curr, unsigned char curr_seg, size_t newSize) {
-	//if the size of the free block is more than the new size,
-	//need to split the block into a first block which is malloc'd
-	//and second block which is still free but has a smaller size 
-	if (newSize < curr_seg) write_free_size(curr+newSize, (curr_seg - newSize));
-	curr -> size = (newSize & 0x7f) | 0x80;
-}
+//void write_occupied_size(metadata* curr, unsigned char curr_seg, size_t newSize) {
+//	//if the size of the free block is more than the new size,
+//	//need to split the block into a first block which is malloc'd
+//	//and second block which is still free but has a smaller size
+//	if (newSize < curr_seg)
+//		dm_write_metadata(curr + newSize, (curr_seg - newSize));
+//	curr -> size = (newSize & 0x7f) | 0x80;
+//}
 
 int is_occupied_page(pagedata* curr) {
 	return  (curr->p_ind) & 0x8000;
 }
+
 void write_free_page(pagedata* curr, unsigned short index) {
   curr->p_ind = (index & 0x7fff);
 }
@@ -86,8 +65,8 @@ void printMemory() {
 		int j = 0;
 		while (j < num_segments) {
 			metadata* mdata = start + j;
-			char curr_seg = block_size(mdata);
-			int isOcc = is_occupied(mdata);
+			char curr_seg = dm_block_size(mdata);
+			int isOcc = dm_block_occupied(mdata);
 			printf("page[%d][%d] pid %d %p: %d  %hu %p\n", i, j, pdata->pid, mdata, isOcc, curr_seg, (start+num_segments) + j*SEGMENTSIZE);
 			j+=curr_seg;	
 		}
@@ -100,7 +79,7 @@ void initialize_pages() {
 		pagedata* pdata = (pagedata*)myblock + i;	
 		write_free_page(pdata, i);
 		metadata* mdata = (metadata*) ((char*)mem_space + i*page_size);
-		write_free_size(mdata, num_segments);
+		dm_write_metadata(mdata, num_segments, 0, 1);
 	}
 }
 
@@ -109,12 +88,13 @@ void* find_free_page(size_t size, uint32_t curr_id) {
 	size_t segments_alloc = size / SEGMENTSIZE + 1;
 	int free_page = -1;
 	int page_exist = -1;
-	int index = (segments_alloc > num_segments) ? num_pages : 0;
+	int index = (segments_alloc > num_segments) ? num_pages : 0; // remove this
+	// check to allow longer allocations
 
 	//if exists, find first fit free space
-	for (index; index < num_pages; index++) {
+	for (; index < num_pages; index++) {
 		pagedata* pdata = (pagedata*)myblock + index;	
-                if ( !is_occupied_page(pdata) ) { //free page
+		if ( !is_occupied_page(pdata) ) { //free page
 			if (free_page == -1) {
 				free_page = index;
 			}
@@ -127,14 +107,13 @@ void* find_free_page(size_t size, uint32_t curr_id) {
 			metadata* start = (metadata*) (mem_space + index*page_size);
 			int seg_index = 0;
 			while ( seg_index < num_segments) {
-				metadata* curr = start + seg_index;
-				unsigned char curr_seg = block_size(curr);
-				if (!is_occupied(curr) && (segments_alloc <= curr_seg ) ) { 
-					write_occupied_size(curr, curr_seg, segments_alloc);
+				metadata* curr = start + seg_index*SEGMENTSIZE;
+				unsigned char curr_seg = dm_block_size(curr);
+				if (!dm_block_occupied(curr) && (segments_alloc <= curr_seg ) ) {
+					dm_allocate_block(curr, segments_alloc);
 					//segment memory space = start + num_segments
 					//free segment = segment memory space + seg_index * SEGMENTSIZE;
-					void* ret = (void*) ( (start+num_segments) + seg_index*SEGMENTSIZE);
-					return ret;
+					return (void*) (curr + 1);
 				}
 				seg_index+=curr_seg;
 			}
@@ -147,11 +126,10 @@ void* find_free_page(size_t size, uint32_t curr_id) {
 	if ( (page_exist == -1 || curr_id == 0) && free_page != -1 ) {
 		write_occupied_page((pagedata*)myblock+free_page, curr_id, free_page);
 		metadata* curr = (metadata*) (mem_space + free_page*page_size);
-		unsigned char curr_seg = block_size(curr);
+		unsigned char curr_seg = dm_block_size(curr);
 		if (segments_alloc <= curr_seg) { 
-			write_occupied_size(curr, curr_seg, segments_alloc);
-			void* ret = (void*) (curr+num_segments) ;
-			return ret;
+			dm_allocate_block(curr, segments_alloc);
+			return (void*) (curr + 1);
 		}
 	}
 
@@ -160,7 +138,7 @@ void* find_free_page(size_t size, uint32_t curr_id) {
 
 //returns to the user a pointer to the amount of memory requested
 void* myallocate(size_t size, char* file, int line, int threadreq){
-  	enter_scheduler(&timer_pause_dump);
+	enter_scheduler(&timer_pause_dump);
 	//if the user asks for 0 bytes, call error and return NULL
 	if (size <= 0){
 		error_message("Cannot malloc 0 or negative bytes", file, line);
@@ -170,9 +148,11 @@ void* myallocate(size_t size, char* file, int line, int threadreq){
 	if (firstMalloc == 1) { // first time using malloc
 		myblock = memalign(sysconf( _SC_PAGESIZE), MEMSIZE);
 		page_size = sysconf( _SC_PAGESIZE);
-		num_segments = page_size / ( SEGMENTSIZE + sizeof(metadata) );
-		num_pages = MEMSIZE / ( page_size + sizeof(pagedata));		
-		mem_space = (char*) ( (pagedata*) myblock + num_pages );
+		num_segments = page_size / SEGMENTSIZE;
+		num_pages = MEMSIZE / ( page_size + sizeof(pagedata));
+		uint32_t pt_space = num_pages*sizeof(pagedata);
+		pt_space = (pt_space % page_size) ? pt_space/page_size + 1 : pt_space/page_size;
+		mem_space = myblock + pt_space*page_size;
 		initialize_pages();
 		memset(&segh, 0, sizeof(struct sigaction));
 		sigemptyset(&segh.sa_mask);
@@ -192,7 +172,8 @@ void* myallocate(size_t size, char* file, int line, int threadreq){
 }
 
 int free_ptr(void* p) {	
-	int page_index = ( (unsigned long) p - (unsigned long) mem_space) / page_size ;
+	int page_index = ( (char*)p - 1 - mem_space) /
+				page_size ;
 	metadata* start = (metadata*) (mem_space + page_index*page_size);
 	metadata* prev;
 	int prevFree = 0;
@@ -201,45 +182,48 @@ int free_ptr(void* p) {
 	int seg_index = (firstMalloc == 1) ? num_segments: 0;
 	//find the pointer to be free and keep track of the previous block incase it is free so we can combine them and avoid memory fragmentation
 	while (seg_index < num_segments) { 
-		metadata* curr = start + seg_index;
-		unsigned char curr_seg = block_size(curr);
+		metadata* curr = start + seg_index*SEGMENTSIZE;
+		unsigned char curr_seg = dm_block_size(curr);
 		//if we find the pointer to be free'd
-		if ( (start+num_segments + seg_index * SEGMENTSIZE) == p) {
+		if ( curr + 1 == p) {
 			//if it is already free, cannot free it -> error
-			if ( !is_occupied(curr) ) {
-				return 1; 
+			if ( !dm_block_occupied(curr) ) {
+				return 1;
 			}
 			else {
-				write_free_size(curr, curr_seg); //free the current pointer
+				// free current pointer
+				dm_write_metadata(curr, curr_seg, 0, dm_is_last_segment(curr));
 				//if the next block is within segment and is free, combine if with my current pointer as a free block
 				if (seg_index+curr_seg < num_segments){
-					metadata* next = start + seg_index + curr_seg;
-					if (!is_occupied(next)){
-						write_free_size(curr, curr_seg+block_size(next));
+					metadata* next = curr + curr_seg*SEGMENTSIZE;
+					if (!dm_block_occupied(next)){
+						dm_write_metadata(curr, curr_seg + dm_block_size(next), 0,
+												dm_is_last_segment(next));
 					}
 				}
 				//if previous block was free, combine my current pointer with previous block
-				if (prevFree) write_free_size(prev, prevSize+block_size(curr));
-				if ( !is_occupied(start) && block_size(start) == num_segments) {
+				if (prevFree) dm_write_metadata(prev, prevSize + dm_block_size(curr),
+																		0, dm_is_last_segment(curr));
+				if (!dm_block_occupied(start) && dm_block_size(start) == num_segments) {
 					write_free_page( (pagedata*)myblock + page_index, page_index );
 				}
 			}		
-  			exit_scheduler(&timer_pause_dump);
+			exit_scheduler(&timer_pause_dump);
 			return 0;
 		}
 		prev = curr;
-		if (!is_occupied(curr)) {
+		if (!dm_block_occupied(curr)) {
 			prevFree = 1;
 			prevSize = curr_seg;
 		}
 		else { 
 			prevFree = 0;
 		}
-		seg_index= seg_index + curr_seg;
+		seg_index += curr_seg;
 	}
 
 	//if we did not return within the while loop, the pointer was not found and thus was not malloc'd
-	return 2; 
+	return 2;
 }
 
 //frees up any memory malloc'd with this pointer for future use
@@ -258,5 +242,5 @@ void mydeallocate(void* p, char* file, int line, int threadreq) {
 	else if (d==2) {
 		error_message("This pointer was not malloc'd!", file, line);
 	}
-  	exit_scheduler(&timer_pause_dump);
+	exit_scheduler(&timer_pause_dump);
 }

--- a/asst2/CODE/my_malloc.h
+++ b/asst2/CODE/my_malloc.h
@@ -10,14 +10,6 @@
 //#define malloc(x) myallocate(x, __FILE__, __LINE__, THREADREQ)
 //#define free(x) mydeallocate(x, __FILE__, __LINE__, THREADREQ)
 
-//metadata is represented as an unsigned char
-//it tells us the number of 64 byte segments
-//which are allocated or free for user data
-//if the leftmost bit is 1, then the block is occupied else free
-struct _metadata_ {
-	unsigned char size;
-} typedef metadata;
-
 struct _pagedata_ {
 	uint32_t pid; //id of process using page
 	unsigned short p_ind; //where process thinks data is; left most bit == 1, is occupied, else free


### PR DESCRIPTION
Implemented new metadata pattern with bits for free/last segment

Have metadata interspersed with data instead in a header chunk
- Increases length of continuous allocations to 4095
- IMPORTANT: Allows allocations to span multiple pages without colliding with metadata header chunks
- Slight performance hit bc of misalignment with cache lines and larger data types